### PR TITLE
chore: stringify the Object log

### DIFF
--- a/src/cosmos/Cosmos.ts
+++ b/src/cosmos/Cosmos.ts
@@ -43,8 +43,9 @@ export class Cosmos {
         assertNotEmpty(key);
         this.client = new CosmosClient({ endpoint, key });
 
-        console.info(`cosmos endpoint: ${endpoint}`);
-        console.info(`cosmos key: ${key.substring(0, 3)}...`);
+        console.info(`
+        cosmos endpoint: ${endpoint}
+        cosmos key: ${key.substring(0, 3)}...`);
     }
 
     public async getDatabase(db: string): Promise<CosmosDatabase> {

--- a/src/cosmos/condition/Condition.js
+++ b/src/cosmos/condition/Condition.js
@@ -53,7 +53,7 @@ exports.toQuerySpec = function (condition, countOnly) {
         query: queryText,
         parameters: params
     };
-    console.info("querySpec:", querySpec);
+    console.info("querySpec:", JSON.stringify(querySpec));
     return querySpec;
 };
 /**

--- a/src/cosmos/condition/Condition.ts
+++ b/src/cosmos/condition/Condition.ts
@@ -86,7 +86,7 @@ export const toQuerySpec = (condition: Condition, countOnly?: boolean): SqlQuery
         parameters: params,
     };
 
-    console.info("querySpec:", querySpec);
+    console.info("querySpec:", JSON.stringify(querySpec));
 
     return querySpec;
 };


### PR DESCRIPTION

![SCR-20220826-orw](https://user-images.githubusercontent.com/65666235/187122378-904b5edc-ad3a-4b65-9032-59f102167dd9.png)


- As shown in the image, the azure function handles the Object data type into multiple lines when logging the logs generated by the `console`.
- In order to streamline the log, I would like to be able to serialize the data of Object type for printing logs.

Thank you very much.